### PR TITLE
Patching a few issues

### DIFF
--- a/update_lunchmoney_from_amazon.py
+++ b/update_lunchmoney_from_amazon.py
@@ -11,7 +11,7 @@ service_id = 'AMAZON_TO_LM'
 #On first run store the Lunch Money API key in the OS keyring. If this needs to be changed later you can change the API key with keyring.set_password(service_id, 'lmauth', 'YOUR_LUNCH_MONEY_API_KEY_HERE')
 if not keyring.get_password(service_id, 'lmauth'):
 	print('Lunch money API key not found.')
-	apikey = str(input('Please enter your Lunch Money API key for secure storage in your operating system's keyring: '))
+	apikey = str(input('Please enter your Lunch Money API key for secure storage in your operating system\'s keyring: '))
 	keyring.set_password(service_id, 'lmauth', apikey)
 	del apikey
 


### PR DESCRIPTION
This PR patches a few issues I encountered trying to use this script.

1. Fixes https://github.com/samwelnella/amazon-transactions-to-lunchmoney/issues/2
2. Switches the payee matching to use regex. This allows for more flexibility on the matches. For instances the old code looked for `AMAZON.COM`, however being from Canada I had `AMAZON.CA` on a lot of my transactions. Regex allows this to easily support any TLD.
3. Switches the cleaning of the float to use regex (just removed any character that isn't a digit or period). This fixed the fact that the Amazon.ca csv exported the totals like `CDN$ 2.52` where the currency wasn't cleaned off with the existing logic